### PR TITLE
Rearranged sizing of blog posts

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -12,6 +12,11 @@ module.exports = eleventyConfig => {
     eleventyConfig.addFilter('limit', function(array, limit) {
       return array.slice(0, limit);
     });
+    
+    // Skips first post with limit
+    eleventyConfig.addFilter('skipFirst', function(array, limit) {
+        return array.slice(1, limit);
+    });
 
     // Minify our HTML
     eleventyConfig.addTransform("htmlmin", (content, outputPath) => {

--- a/site/includes/components/blog/blog-section.njk
+++ b/site/includes/components/blog/blog-section.njk
@@ -20,17 +20,78 @@
 
         {% for post in collections.blog %}
           {% if page.url !=  post.url %}
-            {% set blogPosts = (blogPosts.push(post), blogPosts) %}
+            {% set blogPosts = (blogPosts.push(post), blogPosts)%}
           {% endif %}
         {% endfor %}
 
-        {% for post in blogPosts | limit(3) %}
-          <div class="md:w-1/3 md:px-3 w-full mb-8 sm:mb-10 lg:mb-0 max-w-xs mx-auto">
+        {% for post in blogPosts | limit(1) %}
+          <div class="md:w-full md:px-3 w-full mb-8 sm:mb-10 lg:mb-0 max-w-none mx-auto">
             <div class="flex flex-col rounded-lg shadow-primary md:h-full overflow-hidden">
               {% if post.data.featured_image %}
                 <div class="flex-shrink-0">
                   <img class="h-56 w-full object-cover" data-lazy="{{ post.data.featured_image }}" alt="{{ post.data.featured_image_alt }}" />
                 </div>
+                
+              {% endif %}
+              <div class="flex-1 bg-white px-4 md:px-6 py-6 flex flex-col justify-between relative">
+                <div class="flex-1 mt-2">
+                  {% if post.data.tags %}
+                    <div class="category absolute top-0 flex -my-4 -mx-1">
+                      {% for item in post.data.tags %}
+                        {% if item != "blog" %}
+                          <div class="px-1">
+                            <a href="/category/{{ item }}" class="p-2 bg-red-100 text-white font-bold rounded block font-heading text-sm leading-sm">{{ item | capitalize }}</a>
+                          </div>
+                        {% endif %}
+                      {% endfor %}
+                      </div>
+                  {% endif %}
+                  <a href="#" class="block">
+                    <a href="{{ post.url }}" class="block"><h3 class="text-blue-200 max-w-90 mb-4">{{ post.data.title }}</h3></a>
+                    <p class="mb-6 sm:mb-4 text-sm leading-md">{{ post.data.excerpt }}</p>
+                  </a>
+                </div>
+                <div class="flex">
+                  <div class="mr-2 w-10 h-10">
+                    <img src="../../images/blog/{{post.data.avatar}}" alt="{{post.data.avatar.alt}}" class="w-full h-full object-cover rounded-50 block" />
+                  </div>
+
+                  <div class="{% if post.data.time %}my-auto{% else  %}mt-auto{% endif %}">
+                    {% if post.data.time %}
+                      <p class="time text-blue-200 font-bold font-heading mb-1 text-md sm:text-sm leading-sm">{{ post.data.time }} read time</p>
+                    {% endif %}
+                    
+                    <div class="">
+                      <p class="author text-black text-sm leading-sm sm:text-xs sm:leading-xs">
+                        By {{ post.data.author }}
+                        {% if post.data.date %}
+                          <span class="text-black text-sm leading-sm sm:text-xs sm:leading-xs my-auto">&#8210;</span>
+                          <time datetime="{{ post.data.date }}" class="text-black text-sm leading-sm sm:text-xs sm:leading-xs my-auto">
+                            {{ post.data.date | dateDisplay }}
+                          </time>
+                        {% endif %}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        {% endfor %}
+      </div>
+      
+      <br>
+
+        <div class="flex md:flex-row flex-col max-w-full mx-auto lg:max-w-none lg:-mx-3">
+          
+        {% for post in blogPosts | skipFirst(3) %}
+          <div class="md:w-6/12 md:px-3 w-full mb-8 sm:mb-10 lg:mb-0 max-w-none mx-auto">
+            <div class="flex flex-col rounded-lg shadow-primary md:h-full overflow-hidden">
+              {% if post.data.featured_image %}
+                <div class="flex-shrink-0">
+                  <img class="h-56 w-full object-cover" data-lazy="{{ post.data.featured_image }}" alt="{{ post.data.featured_image_alt }}" />
+                </div>
+                
               {% endif %}
               <div class="flex-1 bg-white px-4 md:px-6 py-6 flex flex-col justify-between relative">
                 <div class="flex-1 mt-2">


### PR DESCRIPTION
Had some trouble with this it wasnt as simple as just changing the classes since all three posts were being generated together using the same html classes so splitting them wasnt an option i have basically run the loop again to generate the bottom and top blogs seperate then I created my own filter to slice the array so the blogs were not repeating.

![Screenshot 2021-03-04 at 17 22 37](https://user-images.githubusercontent.com/34545640/110003571-673d0b00-7d0e-11eb-812b-e4c41719167c.png)
